### PR TITLE
add "HA" prefix to service names

### DIFF
--- a/check_haobserver.py
+++ b/check_haobserver.py
@@ -57,5 +57,5 @@ for row in statrows:
     code='3'
     nicestatus="Unknown"
     perf=' - '
-  print(code + ' "HA ' + service + '"' + perf + service + ' reports ' + nicestatus)
+  print(code + ' "Home Assistant ' + service + '"' + perf + service + ' reports ' + nicestatus)
 exit(0)

--- a/check_haobserver.py
+++ b/check_haobserver.py
@@ -57,5 +57,5 @@ for row in statrows:
     code='3'
     nicestatus="Unknown"
     perf=' - '
-  print(code + ' ' + service + perf + service + ' reports ' + nicestatus)
+  print(code + ' "HA ' + service + '"' + perf + service + ' reports ' + nicestatus)
 exit(0)


### PR DESCRIPTION
so that they are all displayed next to each other and also can be easily checked by some regex

0 "HA Supervisor" connected=1 Supervisor reports Connected
0 "HA Supported" connected=1 Supported reports Supported
0 "HA Healthy" connected=1 Healthy reports Healthy

